### PR TITLE
Add fonts-freefont-ttf to dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project contains the source code for:
 Since cross-compilation has its own complexities, it is probably easier to first start with getting the emulator running on your development machine.  To compile and run the emulator you will need the following dependencies installed:
 
 ```bash
-sudo apt install build-essential libsdl2-dev libsdl2-ttf-dev libfftw3-dev swig python3 zip
+sudo apt install build-essential libsdl2-dev libsdl2-ttf-dev libfftw3-dev swig python3 zip fonts-freefont-ttf
 ```
 
 To compile, execute this in the top directory:


### PR DESCRIPTION
The emulator compiles and runs cleanly on a minimal Debian 10 (Buster) desktop - the only thing which is missing is the FreeSans font which the emulator tries to load. I've confirmed that `fonts-freefont-ttf` package exists for both Debian 10, Ubuntu 18.04, and Ubuntu 20.04 so it seems safe to add it to the list of dependencies.