### PR TITLE
Reproduce linker errors

### DIFF
--- a/tutorial/step2/EuclideanSequencer.cpp
+++ b/tutorial/step2/EuclideanSequencer.cpp
@@ -5,6 +5,7 @@
 //#define BUILDOPT_VERBOSE
 //#define BUILDOPT_DEBUG_LEVEL 10
 #include <hal/log.h>
+#include <sstream>
 
 EuclideanSequencer::EuclideanSequencer(int space)
 {
@@ -19,6 +20,15 @@ EuclideanSequencer::EuclideanSequencer(int space)
   mBoxes.enableSerialization();
   addParameter(mCats);
   mCats.enableSerialization();
+
+  for (int i = 0; i < 4; i++) {
+    std::ostringstream ss;
+    ss << "Test" << i + 1;
+    od::Parameter *param = new od::Parameter(ss.str());
+    param->enableSerialization();
+    addParameterFromHeap(param);
+  }
+
   // Initialize the cats and boxes.
   simulateCatsInBoxes(0, 1);
 }


### PR DESCRIPTION
This change repros a linker error I'm experiencing on the er-301 device but not in the emulator.

Missing symbols:
```
tomfiset@TTOMFIS-GHPJG5J ~/src/er-301 [master|✚ 1] > docker run \
>   --privileged \
>   -v `pwd`:/er-301 \
>   -w /er-301/tutorial/step2 \
>   -it \
>   am335x-build:latest \
>   make -j missing ARCH=am335x PROFILE=release
[NM release/am335x/libFoo.so]
[DIFF release/am335x/imports.txt ../../release/am335x/app/exports.sym]
Missing Symbols:
_ZN2od6Object20addParameterFromHeapEPNS_9ParameterE
```