### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ tmp/
 
 # Packages
 *.pkg
+
+# OSX
+.DS_Store


### PR DESCRIPTION
OSX adds this file to a directory everytime you open a finder window to that dir. Ignore it cause it's annoying.