### PR TITLE
Fix description wrapping

### DIFF
--- a/xroot/Unit/MenuControl/FlagSelect.lua
+++ b/xroot/Unit/MenuControl/FlagSelect.lua
@@ -30,7 +30,7 @@ function FlagSelect:init(args)
   graphic:setBorder(1)
   graphic:setBorderColor(app.GRAY7)
   graphic:setCornerRadius(3, 3, 3, 3)
-  graphic:setMargins(3, 1, (#flags + descWidth - 1) * ply, 1)
+  graphic:setMargins(3, 1, #flags * ply, 1)
   graphic:fitHeight((#flags + descWidth) * ply - 2)
 
   local h = graphic.mHeight // 2

--- a/xroot/Unit/MenuControl/OptionControl.lua
+++ b/xroot/Unit/MenuControl/OptionControl.lua
@@ -39,7 +39,7 @@ function OptionControl:init(args)
   graphic:setBorder(1)
   graphic:setBorderColor(app.GRAY7)
   graphic:setCornerRadius(3, 3, 3, 3)
-  graphic:setMargins(3, 1, (3 + descWidth - 1) * ply, 1)
+  graphic:setMargins(3, 1, 3 * ply, 1)
   graphic:fitHeight((3 + descWidth) * ply - 2)
   local h = graphic.mHeight // 2
   local labels = {}


### PR DESCRIPTION
Fix description text wrapping in the `OptionControl` and `FlagSelect` menu controls.

The issue was that the calculated "right margin" was so large that the description text was never able to properly use the space given by the description width (see [here](https://github.com/odevices/er-301/blob/master/od/graphics/text/RichTextBox.cpp#L96)).

Tested locally with some long descriptions and verified on the Pedal Looper and VariSpeed Player that the options still render correctly.