### PR TITLE
Allow units to define their own scope view

### DIFF
--- a/xroot/Chain/ScopeView.lua
+++ b/xroot/Chain/ScopeView.lua
@@ -35,9 +35,9 @@ function ScopeView:select(xpath)
 end
 
 function ScopeView:loadUnitHelper(unit)
-  -- Traverse each control in the expanded view
+  -- Traverse each control in the scope or expanded view
   -- app.logInfo("%s:loadUnitHelper(%s)",self,unit)
-  local view = unit:getView("expanded")
+  local view = unit:getView("scope") or unit:getView("expanded")
   if view == nil then return end
   local overview = self.ptr
   for i, control in ipairs(view.controls) do

--- a/xroot/Source/LocalChooser.lua
+++ b/xroot/Source/LocalChooser.lua
@@ -65,9 +65,9 @@ function LocalChooser:getXPath()
 end
 
 function LocalChooser:loadUnitHelper(unit)
-  -- Traverse each control in the expanded view
+  -- Traverse each control in the scope or expanded view
   --app.logInfo("%s:loadUnitHelper(%s)",self,unit)
-  local view = unit:getView("expanded")
+  local view = unit:getView("scope") or unit:getView("expanded")
   if view==nil then return end
   local overview = self.ptr
   for i,control in ipairs(view.controls) do


### PR DESCRIPTION
Wishful thinking ;)

This is surprisingly simple but not _perfect_. When the scope view is toggled back to edit mode the cursor lands on whatever position the scope control is on but in the expanded view. If there are more controls in the scope view than in the expanded view then we get:
```
[#163 20.9880s lua] INFO Chain.Root(OUT1,depth=1,6053140b):navigateToXPath:Unit(Sloop,71729443) has no control at index=8
```
so defensive coding saves the day!

Personally I think this is an acceptable bug given the flexibility it adds. Also there is already an issue with cursor position when switching between sub-views so this is not strictly new or out of the ordinary.

Testing:
- [x] Verify fallback case, existing units still display correctly.
- [x] Verify new case, custom scope views display correctly.

