### PR TITLE
Load slices from wav cues if no slc file exists

### DIFF
--- a/od/audio/Sample.h
+++ b/od/audio/Sample.h
@@ -99,7 +99,6 @@ namespace od
     float mSampleRate = 48000.0f;
     float mSamplePeriod = 1.0 / 48000.0f;
     int mOriginalBitDepth = 32;
-    char *mpWavOriginFilename = 0;
 
     float mTotalSeconds = 0;
     // MM:SS.XXX

--- a/od/audio/Sample.h
+++ b/od/audio/Sample.h
@@ -99,6 +99,7 @@ namespace od
     float mSampleRate = 48000.0f;
     float mSamplePeriod = 1.0 / 48000.0f;
     int mOriginalBitDepth = 32;
+    char *mpWavOriginFilename = 0;
 
     float mTotalSeconds = 0;
     // MM:SS.XXX

--- a/od/audio/Slices.cpp
+++ b/od/audio/Slices.cpp
@@ -6,12 +6,14 @@
  */
 
 #include <od/audio/Slices.h>
+#include <od/audio/WavFileReader.h>
 #include <od/extras/FileWriter.h>
 #include <od/extras/FileReader.h>
 #include <hal/simd.h>
 #include <od/config.h>
 #include <hal/log.h>
 #include <algorithm>
+#include <vector>
 
 namespace od
 {
@@ -107,6 +109,37 @@ namespace od
       }
 
       mSorted.push_back(slice);
+    }
+
+    sort();
+
+    return true;
+  }
+
+  bool Slices::loadWavFileCues(const char *filename)
+  {
+    WavFileReader reader;
+
+    if (!reader.open(filename))
+    {
+      return false;
+    }
+
+    std::vector<uint32_t> positions;
+    positions.reserve(reader.getCueCount());
+
+    if (!reader.readCuePositions(positions))
+    {
+      return false;
+    }
+
+    mSorted.clear();
+    mIntervalsNeedRefresh = true;
+    mSorted.reserve(positions.size());
+
+    for (uint32_t position : positions)
+    {
+      mSorted.push_back(Slice { (int)position });
     }
 
     sort();

--- a/od/audio/Slices.cpp
+++ b/od/audio/Slices.cpp
@@ -128,7 +128,7 @@ namespace od
     std::vector<uint32_t> positions;
     positions.reserve(reader.getCueCount());
 
-    if (!reader.readCuePositions(positions))
+    if (!reader.readCues(positions))
     {
       return false;
     }

--- a/od/audio/Slices.h
+++ b/od/audio/Slices.h
@@ -27,6 +27,7 @@ namespace od
 
         bool save(const char *filename);
         bool load(const char *filename);
+        bool loadWavFileCues(const char *filename);
 
         void setSampleRate(float rate);
         void copyFrom(int from, int to, Slices *slices, int sourceStart);

--- a/od/audio/WavFileReader.cpp
+++ b/od/audio/WavFileReader.cpp
@@ -356,21 +356,21 @@ namespace od
     return mCurrentSamplePosition;
   }
 
-  bool WavFileReader::readCuePositions(std::vector<uint32_t> &positions)
+  bool WavFileReader::readCues(std::vector<uint32_t> &positions)
   {
-    uint32_t br, pr = 0;
+    uint32_t br;
 
     if (seekBytes(mCuePointsPosition) != mCuePointsPosition)
     {
       logError(
-          "WavFileReader::readCuePositions: could not seek to cue position (%d).",
+          "WavFileReader::readCues: could not seek to cue position (%d).",
           mCuePointsPosition);
       return false;
     }
 
-    for (int i = 0; i < mCuePointsCount; i++) {
-      CueFormatData data;
-      uint32_t size = sizeof(CueFormatData);
+    for (int i = 0; i < (int)mCuePointsCount; i++) {
+      CuePointData data;
+      uint32_t size = sizeof(CuePointData);
       br = readBytes(&data, size);
       if (br != size) return false;
 

--- a/od/audio/WavFileReader.h
+++ b/od/audio/WavFileReader.h
@@ -18,13 +18,21 @@ namespace od
 		virtual uint32_t seekSamples(uint32_t offset);
 		virtual uint32_t tellSamples();
 
+		bool readCuePositions(std::vector<uint32_t> &positions);
+
 		void describe();
+
+		uint32_t getCueCount();
 
 	protected:
 		uint32_t mCurrentSamplePosition = 0;
 		int mBytesPerChannel = 0;
 		bool mDataIsFloat = false;
 		uint32_t mDataPosition = 0;
+
+		uint32_t mCueDataSize = 0;
+		uint32_t mCuePointsPosition = 0;
+		uint32_t mCuePointsCount = 0;
 
 		WavFormatExData mFormat = {};
 

--- a/od/audio/WavFileReader.h
+++ b/od/audio/WavFileReader.h
@@ -18,7 +18,7 @@ namespace od
 		virtual uint32_t seekSamples(uint32_t offset);
 		virtual uint32_t tellSamples();
 
-		bool readCuePositions(std::vector<uint32_t> &positions);
+		bool readCues(std::vector<uint32_t> &positions);
 
 		void describe();
 

--- a/od/audio/wav.h
+++ b/od/audio/wav.h
@@ -55,4 +55,18 @@ namespace od
 		uint8_t WAVEID[4];
 	} FileTypeChunk;
 
+	typedef struct {
+		uint32_t numCuePoints;
+	} CueChunkData;
+
+	typedef struct
+	{
+		uint8_t id[4];
+		uint32_t position;
+		uint8_t dataChunkId[4];
+		uint32_t chunkStart;
+		uint32_t blockStart;
+		uint32_t sampleOffset;
+	} CueFormatData;
+
 } /* namespace od */

--- a/od/audio/wav.h
+++ b/od/audio/wav.h
@@ -67,6 +67,6 @@ namespace od
 		uint32_t chunkStart;
 		uint32_t blockStart;
 		uint32_t sampleOffset;
-	} CueFormatData;
+	} CuePointData;
 
 } /* namespace od */

--- a/xroot/Sample/Pool/init.lua
+++ b/xroot/Sample/Pool/init.lua
@@ -225,7 +225,10 @@ local function load(path, slicesInfo)
     if slicesInfo then
       sample.slices:deserialize(slicesInfo)
     else
-      sample.slices:load(sample:defaultSlicesPath())
+      local fromPath = sample.slices:load(sample:defaultSlicesPath())
+      if not fromPath then
+        sample.slices:loadWavFileCues(path);
+      end
     end
     Signal.emit("memoryUsageChanged")
     sample:setEnqueuedToLoad()

--- a/xroot/Sample/Pool/init.lua
+++ b/xroot/Sample/Pool/init.lua
@@ -225,8 +225,7 @@ local function load(path, slicesInfo)
     if slicesInfo then
       sample.slices:deserialize(slicesInfo)
     else
-      local fromPath = sample.slices:load(sample:defaultSlicesPath())
-      if not fromPath then
+      if not sample.slices:load(sample:defaultSlicesPath()) then
         sample.slices:loadWavFileCues(path);
       end
     end

--- a/xroot/Sample/Slices.lua
+++ b/xroot/Sample/Slices.lua
@@ -30,6 +30,25 @@ function Slices:load(path)
   end
 end
 
+function Slices:loadWavFileCues(path)
+  if path then
+    path = Path.checkRelativePath(path)
+    self.path = path
+  end
+  if path == nil then return false end
+  if app.pathExists(path) then
+    if self.pSlices:loadWavFileCues(path) then
+      app.logInfo("%s: loaded from wav %s.", self, path)
+      return true
+    else
+      app.logInfo("%s: failed to load from wav %s.", self, path)
+      return false
+    end
+  else
+    return false
+  end
+end
+
 function Slices:save(path)
   if path then
     self.path = path


### PR DESCRIPTION
Thought I'd try my hand at this since it's been talked about on the forum a lot.

Basically we just load the wav cues if there's no slice file present, easy peasy.

Test steps:
1. Create a wav file with some cue markers on it (I used Reaper to do this plus export stems with markers)
2. Load the sample into the sample pool in admin
3. Create a varispeed player and look at the slices, see they match the cue markers.