### PR TITLE
Use branch output in scope view

### DIFF
--- a/xroot/Chain/Branch.lua
+++ b/xroot/Chain/Branch.lua
@@ -47,7 +47,7 @@ function Branch:getOutputDisplayName(channel)
 end
 
 function Branch:getMonitoringOutput(ch)
-  return Chain.getOutput(self, ch)
+  return self:getOutput(ch)
 end
 
 function Branch:getOutput(ch)


### PR DESCRIPTION
Use the branch output... as intended maybe? One line change.

![0007](https://user-images.githubusercontent.com/69446/120673186-f3231800-c460-11eb-9844-e53320d9f828.png)

Might need to be careful of the implications of this. Does it break existing quicksaves? I think the answer is no, since this is just the monitored output.