### PR TITLE
Add callbacks for floating menu change/enter events

### DIFF
--- a/xroot/Overlay.lua
+++ b/xroot/Overlay.lua
@@ -138,7 +138,7 @@ local function getMenuItemsAndDefault()
     end
   end
 
-  return choices, defaultIndex - 1
+  return choices, defaultIndex
 end
 
 local function fireMenuEnter()
@@ -241,7 +241,7 @@ local function onStartFloatingMenu()
 
   if #choices > 1 then
     for _, choice in ipairs(choices) do floatingMenu:add(choice) end
-    floatingMenu:select(defaultIndex)
+    floatingMenu:select(defaultIndex - 1)
     pMainOverlay:addChildOnce(floatingMenu)
   end
 

--- a/xroot/Overlay.lua
+++ b/xroot/Overlay.lua
@@ -116,6 +116,26 @@ local floatingMenu = app.MenuArc()
 local floatingMenuTimer
 local floatingMenuObject
 
+local function getMenuItems()
+  local choices = { "cancel" }
+
+  if floatingMenuObject and floatingMenuObject.getFloatingMenuItems then
+    local items = floatingMenuObject:getFloatingMenuItems() or {}
+    for _, item in ipairs(items) do choices[#choices + 1] = item end
+  end
+
+  return choices
+end
+
+local function getMenuEnterIndex()
+  if floatingMenuObject and floatingMenuObject.getFloatingMenuEnterIndex then
+    return floatingMenuObject:getFloatingMenuEnterIndex()
+  end
+
+  -- start on the first item after 'cancel'
+  return 1
+end
+
 local function fireMenuEnter()
   if floatingMenuObject and floatingMenuObject.onFloatingMenuEnter then
     floatingMenuObject:onFloatingMenuEnter()
@@ -214,18 +234,19 @@ end
 
 local function onStartFloatingMenu()
   floatingMenuTimer = nil
-  local choices = floatingMenuObject:getFloatingMenuItems()
+  local choices = getMenuItems()
+  local enterIndex = getMenuEnterIndex()
   fireMenuEnter()
 
-  if choices and #choices > 0 then
-    floatingMenu:add("cancel")
+  if #choices > 1 then
     for _, choice in ipairs(choices) do floatingMenu:add(choice) end
     pMainOverlay:addChildOnce(floatingMenu)
   end
+
   local Application = require "Application"
   Application.setDispatcher(dispatcherFloatingMenu)
-  -- start on the first item after 'cancel'
-  floatingMenu:scrollDown()
+
+  floatingMenu:select(enterIndex)
 end
 
 local function startFloatingMenu(o)

--- a/xroot/Overlay.lua
+++ b/xroot/Overlay.lua
@@ -215,6 +215,7 @@ end
 local function onStartFloatingMenu()
   floatingMenuTimer = nil
   local choices = floatingMenuObject:getFloatingMenuItems()
+  fireMenuEnter()
 
   if choices and #choices > 0 then
     floatingMenu:add("cancel")
@@ -239,7 +240,6 @@ local function startFloatingMenu(o)
   local x = app.getButtonCenter(Application.getLastMainButtonPressed())
   floatingMenu:setAnchor(x)
   floatingMenuTimer = Timer.after(0.3, onStartFloatingMenu)
-  fireMenuEnter()
 end
 
 local function clearAll()

--- a/xroot/Overlay.lua
+++ b/xroot/Overlay.lua
@@ -117,18 +117,21 @@ local floatingMenuTimer
 local floatingMenuObject
 
 local function fireMenuEnter()
-  if not floatingMenuObject then return end
-  floatingMenuObject:onFloatingMenuEnter()
+  if floatingMenuObject and floatingMenuObject.onFloatingMenuEnter then
+    floatingMenuObject:onFloatingMenuEnter()
+  end
 end
 
 local function fireMenuChange(choice, index)
-  if not floatingMenuObject then return end
-  floatingMenuObject:onFloatingMenuChange(choice, index)
+  if floatingMenuObject and floatingMenuObject.onFloatingMenuChange then
+    floatingMenuObject:onFloatingMenuChange(choice, index)
+  end
 end
 
 local function fireMenuSelection(choice)
-  if not floatingMenuObject then return end
-  floatingMenuObject:onFloatingMenuSelection(choice)
+  if floatingMenuObject and floatingMenuObject.onFloatingMenuSelection then
+    floatingMenuObject:onFloatingMenuSelection(choice)
+  end
 end
 
 local function selectFloatingMenu(choice)

--- a/xroot/SpottedStrip/Control.lua
+++ b/xroot/SpottedStrip/Control.lua
@@ -31,6 +31,13 @@ end
 function Control:getFloatingMenuItems()
 end
 
+function Control:onFloatingMenuEnter()
+end
+
+function Control:onFloatingMenuChange(choice, index)
+  app.logInfo("%s %s", choice, index)
+end
+
 function Control:onFloatingMenuSelection(choice)
 end
 

--- a/xroot/SpottedStrip/Control.lua
+++ b/xroot/SpottedStrip/Control.lua
@@ -35,7 +35,6 @@ function Control:onFloatingMenuEnter()
 end
 
 function Control:onFloatingMenuChange(choice, index)
-  app.logInfo("%s %s", choice, index)
 end
 
 function Control:onFloatingMenuSelection(choice)

--- a/xroot/SpottedStrip/Control.lua
+++ b/xroot/SpottedStrip/Control.lua
@@ -34,7 +34,7 @@ end
 function Control:onFloatingMenuEnter()
 end
 
-function Control:onFloatingMenuChange(choice, index)
+function Control:onFloatingMenuChange(choice)
 end
 
 function Control:onFloatingMenuSelection(choice)

--- a/xroot/SpottedStrip/Section.lua
+++ b/xroot/SpottedStrip/Section.lua
@@ -203,10 +203,7 @@ function Section:spotReleased(viewName, spotHandle, shifted)
       local control = spot:getControl()
       local index = spot:getPositionOnControl()
       local choice = Overlay.endFloatingMenu()
-      if choice then
-        -- app.logInfo("%s:spotReleased:choice='%s'",self,choice)
-        control:onFloatingMenuSelection(choice)
-      else
+      if not choice then
         control:spotReleased(index, shifted)
       end
     end

--- a/xroot/SpottedStrip/Section.lua
+++ b/xroot/SpottedStrip/Section.lua
@@ -187,10 +187,8 @@ function Section:spotPressed(viewName, spotHandle, shifted, isFocusedPress)
     if spot then
       local control = spot:getControl()
       local index = spot:getPositionOnControl()
-      local handled = control:spotPressed(index, shifted, isFocusedPress)
-
-      -- Don't start the menu if the control handled the press.
-      if not handled and control.getFloatingMenuItems then
+      control:spotPressed(index, shifted, isFocusedPress)
+      if control.getFloatingMenuItems then
         Overlay.startFloatingMenu(control)
       end
     end

--- a/xroot/SpottedStrip/Section.lua
+++ b/xroot/SpottedStrip/Section.lua
@@ -187,8 +187,10 @@ function Section:spotPressed(viewName, spotHandle, shifted, isFocusedPress)
     if spot then
       local control = spot:getControl()
       local index = spot:getPositionOnControl()
-      control:spotPressed(index, shifted, isFocusedPress)
-      if control.getFloatingMenuItems then
+      local handled = control:spotPressed(index, shifted, isFocusedPress)
+
+      -- Don't start the menu if the control handled the press.
+      if not handled and control.getFloatingMenuItems then
         Overlay.startFloatingMenu(control)
       end
     end


### PR DESCRIPTION
Add callbacks for floating menu change and enter events.

See [discussion](https://forum.orthogonaldevices.com/t/developing-for-the-er-301/5248/325)

**Testing:**
- [x] Verify menu still works as normal
- [x] Verify changed is called on encoder move
Output from the info log:
```
[#167 7.5638s lua] INFO edit 2
[#168 8.8137s lua] INFO pin to <new> 3
[#169 9.3635s lua] INFO edit 2
[#170 10.0636s lua] INFO expand 1
[#171 12.5969s lua] INFO cancel 0

```
- [x] Verify enter is called on menu start
- [x] Verify menu on header still works 

**Example Usage**
https://forum.orthogonaldevices.com/t/developing-for-the-er-301/5248/333