### PR TITLE
Add module dirs to the require path on load

### DIFF
--- a/xroot/Unit/Factory/init.lua
+++ b/xroot/Unit/Factory/init.lua
@@ -90,12 +90,19 @@ end
 local function instantiateFromLibrary(library, loadInfo, args)
   local loadInfoFound = library:find(loadInfo.moduleName) or loadInfo
   local modulePath = library.name .. "." .. loadInfoFound.moduleName
-  local moduleDir = FS.getRoot("libs") .. "/" .. library.name
 
-  -- First try to load the unit's module
-  -- Add the module dir so files can be looked up without jumping through hoops.
+  local moduleDir = FS.getRoot("libs") .. "/" .. library.name
+  local modulePackagePath = moduleDir .. "/?.lua"
+
+  -- Try to load the unit's module
+  -- Include the module dir in the package path so that modules can require
+  -- their own code without needing to know the outer dir structure. We keep it
+  -- on the end to avoid name conflicts with the core lib.
+  --
+  -- Notably this won't work for modules that require their own code inside
+  -- function calls, since the package path will have been reset by then.
   local originalPath = package.path
-  package.path = moduleDir .. "/?.lua;" .. package.path
+  package.path = package.path .. ";" .. modulePackagePath
   local status, retval = xpcall(require, debug.traceback, modulePath)
   package.path = originalPath
 

--- a/xroot/Unit/Factory/init.lua
+++ b/xroot/Unit/Factory/init.lua
@@ -90,8 +90,15 @@ end
 local function instantiateFromLibrary(library, loadInfo, args)
   local loadInfoFound = library:find(loadInfo.moduleName) or loadInfo
   local modulePath = library.name .. "." .. loadInfoFound.moduleName
+  local moduleDir = FS.getRoot("libs") .. "/" .. library.name
+
   -- First try to load the unit's module
+  -- Add the module dir so files can be looked up without jumping through hoops.
+  local originalPath = package.path
+  package.path = moduleDir .. "/?.lua;" .. package.path
   local status, retval = xpcall(require, debug.traceback, modulePath)
+  package.path = originalPath
+
   if status then
     args.loadInfo = loadInfoFound
     -- Now try to construct the unit


### PR DESCRIPTION
When loading a mod, update the require path to include the base directory for that module, then reset it afterwards.

In particular this is useful for creating _shared_ directories of lua code. When a module is packaged we copy the shared code into that package, but since we don't know the actual module in question the shared code has no way to reference itself.

This change makes it so shared code can require itself without needing to know which module it's a part of.

**Testing**
- [x] Tested with an example project locally