### PR TITLE
Fix monitor output

### DIFF
--- a/xroot/Chain/Branch.lua
+++ b/xroot/Chain/Branch.lua
@@ -47,7 +47,7 @@ function Branch:getOutputDisplayName(channel)
 end
 
 function Branch:getMonitoringOutput(ch)
-  return self:getOutput(ch)
+  return Chain.getOutput(self, ch)
 end
 
 function Branch:getOutput(ch)

--- a/xroot/Chain/ScopeView.lua
+++ b/xroot/Chain/ScopeView.lua
@@ -160,9 +160,9 @@ function ScopeView:onSelectionChanged()
     elseif node.type == "MonoSource" then
       self.scope:watchOutlet(node.o:getOutlet())
     elseif node.type == "Unit" then
-      self.scope:watchOutlet(node.o:getMonitoringOutput(side))
+      self.scope:watchOutlet(node.o:getOutput(side))
     elseif node.type == "Branch" then
-      self.scope:watchOutlet(node.o:getMonitoringOutput(side))
+      self.scope:watchOutlet(node.o:getOutput(side))
     elseif node.type == "Patch" then
       self.scope:watchOutlet(node.o:getMonitoringOutput(side))
     end

--- a/xroot/Source/LocalChooser.lua
+++ b/xroot/Source/LocalChooser.lua
@@ -192,7 +192,7 @@ function LocalChooser:onSelectionChanged()
     elseif node.type=="Unit" then
       self.scope:watchOutlet(node.o:getOutput(side))
     elseif node.type=="Branch" then
-      self.scope:watchOutlet(node.o:getMonitoringOutput(side))
+      self.scope:watchOutlet(node.o:getOutput(side))
     elseif node.type=="Patch" then
       self.scope:watchOutlet(node.o:getMonitoringOutput(side))
     end


### PR DESCRIPTION
## https://github.com/odevices/er-301/issues/53

First of all revert https://github.com/odevices/er-301/pull/34

Second, update the local chooser and scope view to use the normal output instead of the pre-gainbias out.

**Before:**
The sub-chain monitor shows the signal _post_ gain bias, which is wrong. The local and scope correctly show post gain bias.
![before-branch-fix](https://user-images.githubusercontent.com/69446/141883625-dc018f6f-a5ac-4912-a7ee-3a3cec244567.gif)

**After:**
Now the sub-chain monitor shows the pre gain bias, but the local and scope views show post.
![after-branch-fix](https://user-images.githubusercontent.com/69446/141883656-a4e14bc5-6543-4177-aca4-ad59db39deb2.gif)


