### PR TITLE
Update emulator to support Apple M1 arch

### DIFF
--- a/emu/hal/neon.h
+++ b/emu/hal/neon.h
@@ -5,8 +5,12 @@ extern "C"
 {
 #endif
 
-#define USE_SSE4
-#include <hal/neon2sse.h>
+#ifdef __x86_64__
+  #define USE_SSE4
+  #include <hal/neon2sse.h>
+#else
+  #include <arm_neon.h>
+#endif
 
 #ifdef __cplusplus
 }

--- a/emu/hal/neon.h
+++ b/emu/hal/neon.h
@@ -5,11 +5,11 @@ extern "C"
 {
 #endif
 
-#ifdef __x86_64__
+#ifdef __ARM_NEON
+  #include <arm_neon.h>
+#else
   #define USE_SSE4
   #include <hal/neon2sse.h>
-#else
-  #include <arm_neon.h>
 #endif
 
 #ifdef __cplusplus

--- a/mods/core/objects/delays/DopplerDelay.cpp
+++ b/mods/core/objects/delays/DopplerDelay.cpp
@@ -91,7 +91,7 @@ namespace od
 
   static inline int sampleDistance(float *small, float *big)
   {
-    ptrdiff_t d = big - small;
+    std::ptrdiff_t d = big - small;
     return d;
   }
 

--- a/mods/core/objects/granular/GrainStretch.cpp
+++ b/mods/core/objects/granular/GrainStretch.cpp
@@ -4,6 +4,7 @@
 #include <hal/ops.h>
 #include <algorithm>
 #include <string.h>
+#include <math.h>
 
 namespace od
 {

--- a/scripts/darwin.mk
+++ b/scripts/darwin.mk
@@ -1,11 +1,16 @@
 # Build Tools for OSX
-CC := gcc-11 -fdiagnostics-color -fmax-errors=5
-CPP := g++-11 -fdiagnostics-color -fmax-errors=5
+GCC_VERSION = 10
+ifeq ($(shell uname -p),arm)
+  GCC_VERSION = 11
+endif
+
+CC := gcc-$(GCC_VERSION) -fdiagnostics-color -fmax-errors=5
+CPP := g++-$(GCC_VERSION) -fdiagnostics-color -fmax-errors=5
 OBJCOPY := objcopy
 OBJDUMP := objdump
 ADDR2LINE := addr2line
 LD := ld
-AR := gcc-ar-11
+AR := gcc-ar-$(GCC_VERSION)
 SIZE := size
 STRIP := strip
 READELF := readelf

--- a/scripts/darwin.mk
+++ b/scripts/darwin.mk
@@ -1,4 +1,11 @@
 # Build Tools for OSX
+
+# If the processor arch is arm (aka Apple M1) use gcc@11 instead. At the moment
+# there isn't a gcc@10 build available for the M1 chip and even worse the
+# gcc@11 install from homebrew can't seem to find certain header files...
+#
+# For now this will have to do, may want to update this in the future if
+# eventually they can use the same version.
 GCC_VERSION = 10
 ifeq ($(shell uname -p),arm)
   GCC_VERSION = 11

--- a/scripts/darwin.mk
+++ b/scripts/darwin.mk
@@ -1,11 +1,11 @@
 # Build Tools for OSX
-CC := gcc-10 -fdiagnostics-color -fmax-errors=5
-CPP := g++-10 -fdiagnostics-color -fmax-errors=5
+CC := gcc-11 -fdiagnostics-color -fmax-errors=5
+CPP := g++-11 -fdiagnostics-color -fmax-errors=5
 OBJCOPY := objcopy
 OBJDUMP := objdump
 ADDR2LINE := addr2line
 LD := ld
-AR := gcc-ar-10
+AR := gcc-ar-11
 SIZE := size
 STRIP := strip
 READELF := readelf

--- a/scripts/env.mk
+++ b/scripts/env.mk
@@ -118,7 +118,7 @@ pkg_install_dir = $(HOME)/.od/rear
 include scripts/darwin.mk
 
 includes += emu
-CFLAGS.darwin = -Wno-deprecated-declarations -msse4 -fPIC
+CFLAGS.darwin = -Wno-deprecated-declarations -march=native -fPIC
 endif
 
 ###########################

--- a/scripts/tutorial.mk
+++ b/scripts/tutorial.mk
@@ -47,7 +47,7 @@ endif
 
 ifeq ($(ARCH),darwin)
 INSTALLPATH.darwin = $(HOME)/.od/rear
-CFLAGS.darwin = -Wno-deprecated-declarations -msse4 -fPIC
+CFLAGS.darwin = -Wno-deprecated-declarations -march=native -fPIC
 LFLAGS = -dynamic -undefined dynamic_lookup -lSystem
 includes += $(SDKPATH)/emu
 include $(SDKPATH)/scripts/darwin.mk


### PR DESCRIPTION
The Apple M1 chips use NEON for simd, so we can update the hal to simply use the appropriate header.

There's a couple other touch ups here and there as well.

**Testing**
- [x] Works on M1 machine.
- [x] Works on x86 machine.