### PR TITLE
Adjust the readout cursor based on orientation

### DIFF
--- a/od/graphics/controls/Readout.cpp
+++ b/od/graphics/controls/Readout.cpp
@@ -253,8 +253,28 @@ namespace od
 
     fb.text(mForeground, textLeft, mWorldBottom, mText.c_str(), mTextSize);
 
-    mCursorState.x = textLeft - 10;
-    mCursorState.y = mWorldBottom + mTextHeight / 2;
+    int cursorPad = 10;
+    int textRight = textLeft + mTextWidth;
+    switch (mCursorState.orientation)
+    {
+    default:
+    case cursorRight:
+      mCursorState.x = textLeft - cursorPad;
+      mCursorState.y = mWorldBottom + mTextHeight / 2;
+      break;
+    case cursorDown:
+      mCursorState.x = textLeft + mTextWidth / 2;
+      mCursorState.y = mWorldBottom + mTextHeight + cursorPad;
+      break;
+    case cursorLeft:
+      mCursorState.x = textRight + cursorPad;
+      mCursorState.y = mWorldBottom + mTextHeight / 2;
+      break;
+    case cursorUp:
+      mCursorState.x = textLeft + mTextWidth / 2;
+      mCursorState.y = mWorldBottom - cursorPad;
+      break;
+    }
   }
 
   void Readout::encoder(int change, bool shifted, bool fine)

--- a/od/graphics/controls/Readout.cpp
+++ b/od/graphics/controls/Readout.cpp
@@ -253,26 +253,31 @@ namespace od
 
     fb.text(mForeground, textLeft, mWorldBottom, mText.c_str(), mTextSize);
 
-    int cursorPad = 10;
     int textRight = textLeft + mTextWidth;
+    int textTop = mWorldBottom + mTextHeight;
+    int textBottom = mWorldBottom;
+    int textCenterY = mWorldBottom + mTextHeight / 2;
+    int textCenterX = textLeft + mTextWidth / 2;
+
+    int cursorPad = 10;
     switch (mCursorState.orientation)
     {
     default:
     case cursorRight:
       mCursorState.x = textLeft - cursorPad;
-      mCursorState.y = mWorldBottom + mTextHeight / 2;
+      mCursorState.y = textCenterY;
       break;
     case cursorDown:
-      mCursorState.x = textLeft + mTextWidth / 2;
-      mCursorState.y = mWorldBottom + mTextHeight + cursorPad;
+      mCursorState.x = textCenterX;
+      mCursorState.y = textTop + cursorPad;
       break;
     case cursorLeft:
       mCursorState.x = textRight + cursorPad;
-      mCursorState.y = mWorldBottom + mTextHeight / 2;
+      mCursorState.y = textCenterY;
       break;
     case cursorUp:
-      mCursorState.x = textLeft + mTextWidth / 2;
-      mCursorState.y = mWorldBottom - cursorPad;
+      mCursorState.x = textCenterX;
+      mCursorState.y = textBottom - cursorPad;
       break;
     }
   }


### PR DESCRIPTION
I've been experimenting with some new UI layouts and noticed that `Readout`s don't currently honor the cursor orientation when setting the cursor position.

This change updates the cursor position calculation to switch on cursor orientation:
* If the cursor points **right**, use the **left middle** side of the text.
* If the cursor points **left**, use the **right middle** side of the text.
* If the cursor points **down**, use the **top middle** side of the text.
* If the cursor points **up**, use the **bottom middle** side of the text.

Example of my use case with this code, I want the cursor to point left so it doesn't cover up the readout right next to it:

<img width="188" alt="Screen Shot 2022-01-09 at 2 35 15 AM" src="https://user-images.githubusercontent.com/69446/148673587-7f6bf25c-596b-47fd-9091-84937f0fb150.png">

An alternative approach I considered was to draw a box around the readout (instead of using the cursor), but unfortunately there is no reliable way to extract the text dimensions that it calculates.
