### PR TITLE
Update the section view to support setting a background graphic

### DIFF
--- a/xroot/SpottedStrip/SectionView.lua
+++ b/xroot/SpottedStrip/SectionView.lua
@@ -20,12 +20,21 @@ function SectionView:addDivider(x)
   self.dividers[#self.dividers + 1] = x
 end
 
+--- Set the background graphic for this section view.
+function SectionView:setBackground(graphic)
+  self.background = graphic
+end
+
 function SectionView:rebuild(pSection)
   pSection:clear()
   self.spots = {}
 
   for _, x in ipairs(self.dividers) do
     pSection:addVerticalDivider(x)
+  end
+
+  if self.background then
+    pSection:addChild(self.background)
   end
 
   for _, control in ipairs(self.controls) do

--- a/xroot/Unit/init.lua
+++ b/xroot/Unit/init.lua
@@ -165,6 +165,20 @@ function Unit:setTitle(title)
   end
 end
 
+--- Set the background graphic for the named view
+-- @param name    The name of the view created by onLoadViews.
+-- @param graphic The background graphic to use.
+function Unit:setViewBackground(name, graphic)
+  local view = self:getView(name)
+  if view then
+    -- Place the background graphic position after the unit header.
+    graphic:setPosition(app.SECTION_PLY, 0)
+    view:setBackground(graphic)
+  else
+    app.logError("Unit.setViewBackground: view '%s' does not exist.", name)
+  end
+end
+
 -- syntax sugar for Unit definition
 function Unit:addToMuteGroup(control)
   self.chain:addToMuteGroup(control)


### PR DESCRIPTION
Modify the unit SectionView to allow setting a background graphic, see discussion https://github.com/odevices/er-301/discussions/78

Testing
- [x] Verify error message
```
[142 11.2818s lua] ERROR Unit.setViewBackground: view 'expaded' does not exist.
```
- [x] Verify background graphic renders
```
# In unit definition:
function Sieve:onLoadFinished()
  local graphic = app.MiniScope(0, 0, 5 * app.SECTION_PLY, 64)
  graphic:watchOutlet(self:getMonitoringOutput(1))
  self:setViewBackground("expanded", graphic)
end
```
![0006](https://user-images.githubusercontent.com/69446/214756434-3ca98d12-ccd0-409e-81b9-31cd514a0754.png)

A more complete view showing sloop taking full advantage of this background layer:

![sloop-view-background-2](https://user-images.githubusercontent.com/69446/216888768-3451ec14-2660-4171-bf0f-b9d7edb2fc71.gif)

